### PR TITLE
Enhance password reset flow with configurable URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ reply_express-*.tar
 # Local logs
 erl_crash.dump
 
+# Local config
+dev.local.exs

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
 To start your Phoenix server:
 
+  * Copy `dev.local.example.exs` to `dev.local.exs` and fill in the values
   * Run `mix setup` to install and setup dependencies
   * Start Phoenix endpoint with `mix phx.server` or inside IEx with `iex -S mix phx.server`
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -83,3 +83,7 @@ config :swoosh, :api_client, false
 #  port: 1025,
 #  retries: 2,
 #  no_mx_lookups: false
+
+# Import dev local env specific config. This must remain at the bottom
+# of this file so it overrides the configuration defined above.
+import_config "dev.local.exs"

--- a/config/dev.local.example.exs
+++ b/config/dev.local.example.exs
@@ -1,0 +1,3 @@
+import Config
+
+config :reply_express, reset_password_url: "http://localhost:3000/reset-password"

--- a/lib/reply_express/accounts/aggregates/user.ex
+++ b/lib/reply_express/accounts/aggregates/user.ex
@@ -14,7 +14,6 @@ defmodule ReplyExpress.Accounts.Aggregates.User do
   alias ReplyExpress.Accounts.Events.UserRegistered
   alias ReplyExpress.Accounts.Events.UserTokensCleared
 
-
   defstruct [:email, :hashed_password, :logged_in_at, :uuid]
 
   def execute(%User{}, %ClearUserTokens{} = clear_user_tokens) do
@@ -41,7 +40,6 @@ defmodule ReplyExpress.Accounts.Aggregates.User do
     %PasswordReset{hashed_password: reset_password.hashed_password, uuid: uuid}
   end
 
-  
   # Mutators
   def apply(%User{} = user, %UserLoggedIn{} = logged_in) do
     %User{user | logged_in_at: logged_in.logged_in_at, uuid: logged_in.uuid}
@@ -54,6 +52,10 @@ defmodule ReplyExpress.Accounts.Aggregates.User do
         email: registered.email,
         hashed_password: registered.hashed_password
     }
+  end
+
+  def apply(%User{} = user, %PasswordReset{} = reset) do
+    %User{user | hashed_password: reset.hashed_password}
   end
 
   def apply(%User{} = user, _event), do: user

--- a/lib/reply_express/accounts/aggregates/user.ex
+++ b/lib/reply_express/accounts/aggregates/user.ex
@@ -55,7 +55,7 @@ defmodule ReplyExpress.Accounts.Aggregates.User do
   end
 
   def apply(%User{} = user, %PasswordReset{} = reset) do
-    %User{user | hashed_password: reset.hashed_password}
+    %User{user | hashed_password: reset.hashed_password, uuid: user.uuid}
   end
 
   def apply(%User{} = user, _event), do: user

--- a/lib/reply_express/accounts/commands/reset_password.ex
+++ b/lib/reply_express/accounts/commands/reset_password.ex
@@ -27,8 +27,6 @@ defmodule ReplyExpress.Accounts.Commands.ResetPassword do
     by: &ResetPasswordTokenExists.validate/2
   )
 
-  validates(:uuid, presence: [message: "can't be empty"])
-
   @doc """
   Hash the password and preserve the original password
   """

--- a/lib/reply_express/accounts/projectors/user.ex
+++ b/lib/reply_express/accounts/projectors/user.ex
@@ -10,9 +10,14 @@ defmodule ReplyExpress.Accounts.Projectors.User do
     repo: ReplyExpress.Repo
 
   alias Ecto.Multi
+  alias ReplyExpress.Accounts.Events.PasswordReset
   alias ReplyExpress.Accounts.Events.UserLoggedIn
   alias ReplyExpress.Accounts.Events.UserRegistered
   alias ReplyExpress.Accounts.Projections.User, as: UserProjection
+
+  project(%PasswordReset{} = reset, _metadata, fn multi ->
+    update_user(multi, reset.uuid, hashed_password: reset.hashed_password)
+  end)
 
   project(%UserLoggedIn{} = user_logged_in, _metadata, fn multi ->
     logged_in_at =

--- a/lib/reply_express/accounts/services/user_notifier.ex
+++ b/lib/reply_express/accounts/services/user_notifier.ex
@@ -20,7 +20,7 @@ defmodule ReplyExpress.Accounts.Services.UserNotifier do
 
     You can reset your password by visiting the URL below:
 
-    #{url}?token=#{token}
+    #{url}#{if is_binary(url) and String.contains?(url, "?"), do: "&", else: "?"}token=#{URI.encode_www_form(token)}
 
     If you didn't request this change, please ignore this.
 

--- a/lib/reply_express/accounts/services/user_notifier.ex
+++ b/lib/reply_express/accounts/services/user_notifier.ex
@@ -11,7 +11,7 @@ defmodule ReplyExpress.Accounts.Services.UserNotifier do
   @doc """
   Deliver instructions to reset a user password.
   """
-  def deliver_reset_password_instructions({name, _email} = to, url) do
+  def deliver_reset_password_instructions({name, _email} = to, url, token) do
     deliver(to, "Reset password instructions", """
 
     ==============================
@@ -20,7 +20,7 @@ defmodule ReplyExpress.Accounts.Services.UserNotifier do
 
     You can reset your password by visiting the URL below:
 
-    #{url}
+    #{url}?token=#{token}
 
     If you didn't request this change, please ignore this.
 

--- a/lib/reply_express/accounts/users_context.ex
+++ b/lib/reply_express/accounts/users_context.ex
@@ -85,7 +85,6 @@ defmodule ReplyExpress.Accounts.UsersContext do
     |> Commanded.dispatch(consistency: :strong)
   end
 
-  # TODO: Verify dead function
   defp reset_user_session(log_in_user) do
     clear_user_tokens =
       log_in_user

--- a/lib/reply_express_web/controllers/api/v1/users/reset_password_token_controller.ex
+++ b/lib/reply_express_web/controllers/api/v1/users/reset_password_token_controller.ex
@@ -15,7 +15,7 @@ defmodule ReplyExpressWeb.API.V1.Users.ResetPasswordTokenController do
 
       UserNotifier.deliver_reset_password_instructions(
         {"", user_token_projection.user.email},
-        "http://localhost:4000/api/v1/users/change_password",
+        Application.get_env(:reply_express, :reset_password_url),
         token
       )
 

--- a/lib/reply_express_web/controllers/api/v1/users/reset_password_token_controller.ex
+++ b/lib/reply_express_web/controllers/api/v1/users/reset_password_token_controller.ex
@@ -11,9 +11,12 @@ defmodule ReplyExpressWeb.API.V1.Users.ResetPasswordTokenController do
     result = UsersContext.generate_password_reset_token(%{email: email})
 
     with {:ok, %UserTokenProjection{} = user_token_projection} <- result do
+      token = Base.encode64(user_token_projection.token)
+
       UserNotifier.deliver_reset_password_instructions(
         {"", user_token_projection.user.email},
-        "http://localhost:4000/api/v1/users/change_password"
+        "http://localhost:4000/api/v1/users/change_password",
+        token
       )
 
       send_resp(conn, 204, "")

--- a/lib/reply_express_web/router.ex
+++ b/lib/reply_express_web/router.ex
@@ -27,10 +27,10 @@ defmodule ReplyExpressWeb.Router do
 
     scope path: "/users", alias: Users do
       # User authentication
-      post "/log_in", SessionController, :create
+      post "/login", SessionController, :create
       post "/register", RegistrationController, :create
-      post "/reset_password_token", ResetPasswordTokenController, :create
-      post "/reset_password", ResetPasswordController, :create
+      post "/reset-password-token", ResetPasswordTokenController, :create
+      post "/reset-password", ResetPasswordController, :create
     end
   end
 end

--- a/test/reply_express/accounts/users_context_test.exs
+++ b/test/reply_express/accounts/users_context_test.exs
@@ -145,7 +145,6 @@ defmodule ReplyExpress.Accounts.UsersContext.Test do
 
       assert errors.password == ["can't be empty"]
       assert errors.token == ["can't be empty"]
-      assert errors.uuid == ["can't be empty"]
     end
 
     test "Validates password_confirmation", %{user_token: user_token} do

--- a/test/reply_express_web/controllers/api/v1/users/reset_password_controller_test.exs
+++ b/test/reply_express_web/controllers/api/v1/users/reset_password_controller_test.exs
@@ -3,43 +3,44 @@ defmodule ReplyExpressWeb.API.V1.Users.ResetPasswordControllerTest do
 
   use ReplyExpressWeb.ConnCase
 
-  import ReplyExpress.Factory
+  alias ReplyExpress.Accounts.Commands.GeneratePasswordResetToken
+  alias ReplyExpress.Accounts.Commands.RegisterUser
+  alias ReplyExpress.Accounts.Projections.UserToken, as: UserTokenProjection
+  alias ReplyExpress.Commanded
 
-  import ReplyExpress.Factory
+  @valid_credentials %{email: "test@email.local", password: "password1234"}
 
   describe "POST /api/v1/users/reset-password" do
-  @valid_email "test@email.local"
-
-  describe "POST /api/v1/users/reset_password" do
     setup do
-      user =
-        :user_projection
-        |> build(email: @valid_email)
-        |> set_user_projection_password(@valid_password)
-        |> insert()
+      cmd_register_user = %RegisterUser{
+        email: @valid_credentials.email,
+        hashed_password: Pbkdf2.hash_pwd_salt(@valid_credentials.password),
+        password: @valid_credentials.password,
+        uuid: UUID.uuid4()
+      }
 
-      # Simulate the generation of a reset password token
-      token_context = "reset_password"
+      :ok = Commanded.dispatch(cmd_register_user, consistency: :strong)
 
-      user_token =
-        :user_token_projection
-        |> build(user: user, context: token_context)
-        |> insert()
+      cmd_reset =
+        GeneratePasswordResetToken.new(%{email: @valid_credentials.email})
+        |> GeneratePasswordResetToken.assign_uuid(UUID.uuid4())
+        |> GeneratePasswordResetToken.build_reset_password_token()
+        |> GeneratePasswordResetToken.set_user_properties()
 
-      encoded_token = Base.encode64(user_token.token)
+      :ok = Commanded.dispatch(cmd_reset, consistency: :strong)
 
-      {:ok, user: user, user_token: user_token, encoded_token: encoded_token}
+      user_token = Repo.one(UserTokenProjection)
+
+      {:ok, encoded_token: Base.encode64(user_token.token)}
     end
 
     test "successfully resets password and returns 204", %{
       conn: conn,
-      encoded_token: encoded_token,
-      user: user
+      encoded_token: encoded_token
     } do
       params = %{
-        "email" => user.email,
-        "password" => @valid_password,
-        "password_confirmation" => @valid_password,
+        "password" => @valid_credentials.password,
+        "password_confirmation" => @valid_credentials.password,
         "token" => encoded_token
       }
 
@@ -59,16 +60,13 @@ defmodule ReplyExpressWeb.API.V1.Users.ResetPasswordControllerTest do
 
       assert result["errors"]["password"] == ["can't be empty"]
       assert result["errors"]["token"] == ["can't be empty"]
-      assert result["errors"]["uuid"] == ["can't be empty"]
     end
 
-    test "returns 422 for invalid token", %{conn: conn, user: user} do
+    test "returns 422 for invalid token", %{conn: conn} do
       params = %{
-        "email" => user.email,
-        "password" => @valid_password,
-        "password_confirmation" => @valid_password,
-        "token" => Base.encode64("invalidtoken"),
-        "uuid" => user.uuid
+        "password" => @valid_credentials.password,
+        "password_confirmation" => @valid_credentials.password,
+        "token" => Base.encode64("invalidtoken")
       }
 
       result =
@@ -77,7 +75,6 @@ defmodule ReplyExpressWeb.API.V1.Users.ResetPasswordControllerTest do
         |> json_response(422)
 
       assert result["errors"]["token"] == ["invalid token"]
-      assert result["errors"]["uuid"] == ["can't be empty"]
     end
   end
 end

--- a/test/reply_express_web/controllers/api/v1/users/reset_password_controller_test.exs
+++ b/test/reply_express_web/controllers/api/v1/users/reset_password_controller_test.exs
@@ -7,7 +7,7 @@ defmodule ReplyExpressWeb.API.V1.Users.ResetPasswordControllerTest do
 
   import ReplyExpress.Factory
 
-  @valid_password "password1234"
+  describe "POST /api/v1/users/reset-password" do
   @valid_email "test@email.local"
 
   describe "POST /api/v1/users/reset_password" do
@@ -45,7 +45,7 @@ defmodule ReplyExpressWeb.API.V1.Users.ResetPasswordControllerTest do
 
       result =
         conn
-        |> post(~p"/api/v1/users/reset_password", params)
+        |> post(~p"/api/v1/users/reset-password", params)
         |> response(204)
 
       assert result == ""
@@ -54,7 +54,7 @@ defmodule ReplyExpressWeb.API.V1.Users.ResetPasswordControllerTest do
     test "returns 422 when params are missing", %{conn: conn} do
       result =
         conn
-        |> post(~p"/api/v1/users/reset_password", %{})
+        |> post(~p"/api/v1/users/reset-password", %{})
         |> json_response(422)
 
       assert result["errors"]["password"] == ["can't be empty"]
@@ -73,7 +73,7 @@ defmodule ReplyExpressWeb.API.V1.Users.ResetPasswordControllerTest do
 
       result =
         conn
-        |> post(~p"/api/v1/users/reset_password", params)
+        |> post(~p"/api/v1/users/reset-password", params)
         |> json_response(422)
 
       assert result["errors"]["token"] == ["invalid token"]

--- a/test/reply_express_web/controllers/api/v1/users/reset_password_token_controller_test.exs
+++ b/test/reply_express_web/controllers/api/v1/users/reset_password_token_controller_test.exs
@@ -10,7 +10,7 @@ defmodule ReplyExpressWeb.API.V1.Users.ResetPasswordTokenControllerTest do
   #  @invalid_credentials %{email: "test@email", password: "1234"}
   @valid_credentials %{email: "test@email.local", password: "password1234"}
 
-  describe "POST /api/v1/users/reset_password_token" do
+  describe "POST /api/v1/users/reset-password-token" do
     test "creates new reset password token and sends notification email", context do
       user_projection =
         :user_projection
@@ -28,7 +28,7 @@ defmodule ReplyExpressWeb.API.V1.Users.ResetPasswordTokenControllerTest do
       )
 
       context.conn
-      |> post(~p"/api/v1/users/reset_password_token", %{"email" => @valid_credentials.email})
+      |> post(~p"/api/v1/users/reset-password-token", %{"email" => @valid_credentials.email})
       |> response(204)
 
       [user_token_projection] = Repo.all(UserTokenProjection)
@@ -54,7 +54,7 @@ defmodule ReplyExpressWeb.API.V1.Users.ResetPasswordTokenControllerTest do
       )
 
       context.conn
-      |> post(~p"/api/v1/users/reset_password_token", %{"email" => @valid_credentials.email})
+      |> post(~p"/api/v1/users/reset-password-token", %{"email" => @valid_credentials.email})
       |> response(204)
 
       assert_email_sent(fn sent_email ->

--- a/test/reply_express_web/controllers/api/v1/users/session_controller_test.exs
+++ b/test/reply_express_web/controllers/api/v1/users/session_controller_test.exs
@@ -15,7 +15,7 @@ defmodule ReplyExpressWeb.API.V1.Users.SessionControllerTest do
   @invalid_credentials %{email: "test@email", password: "1234"}
   @valid_credentials %{email: "test@email.local", password: "password1234"}
 
-  describe "POST /api/v1/users/log_in" do
+  describe "POST /api/v1/users/login" do
     test "sets cookie with token for session tracking", context do
       command = %RegisterUser{
         email: @valid_credentials.email,
@@ -27,7 +27,7 @@ defmodule ReplyExpressWeb.API.V1.Users.SessionControllerTest do
       :ok = Commanded.dispatch(command, consistency: :strong)
 
       response =
-        post(context.conn, ~p"/api/v1/users/log_in", %{"credentials" => @valid_credentials})
+        post(context.conn, ~p"/api/v1/users/login", %{"credentials" => @valid_credentials})
 
       token = UserToken |> Repo.one() |> Map.get(:token)
 
@@ -61,7 +61,7 @@ defmodule ReplyExpressWeb.API.V1.Users.SessionControllerTest do
 
       response =
         context.conn
-        |> post(~p"/api/v1/users/log_in", %{"credentials" => @invalid_credentials})
+        |> post(~p"/api/v1/users/login", %{"credentials" => @invalid_credentials})
         |> json_response(422)
 
       assert response["errors"]["credentials"] == ["are invalid"]
@@ -70,7 +70,7 @@ defmodule ReplyExpressWeb.API.V1.Users.SessionControllerTest do
     test "handles empty POST body", context do
       response =
         context.conn
-        |> post(~p"/api/v1/users/log_in", %{})
+        |> post(~p"/api/v1/users/login", %{})
         |> json_response(422)
 
       assert response["errors"]["credentials"] == ["is required"]


### PR DESCRIPTION
This PR improves the password reset functionality by making it more configurable and user-friendly:

- Adds support for local development configuration with `dev.local.exs` (gitignored)
- Makes password reset URL configurable instead of hardcoded
- Fixes password reset implementation by:
  - Adding missing event handler in user projector
  - Removing unnecessary UUID validation from reset password command
  - Properly encoding token in reset password emails
  - Using kebab-case for API endpoint URLs

These changes make the password reset flow more robust and provide better separation of configuration for different environments.