### PR TITLE
Fixes type spec field names for team user projection

### DIFF
--- a/lib/reply_express/accounts/projections/team_user.ex
+++ b/lib/reply_express/accounts/projections/team_user.ex
@@ -12,8 +12,8 @@ defmodule ReplyExpress.Accounts.Projections.TeamUser do
 
   @type t :: %__MODULE__{
           role: String.t() | nil,
-          team_id: binary() | nil,
-          user_id: binary() | nil,
+          team_uuid: binary() | nil,
+          user_uuid: binary() | nil,
           team: TeamProjection.t() | Ecto.Association.NotLoaded.t() | nil,
           user: UserProjection.t() | Ecto.Association.NotLoaded.t() | nil,
           inserted_at: DateTime.t() | nil,


### PR DESCRIPTION
Updates the type specification to use consistent naming conventions by aligning field names with the actual schema structure.

- Renames `team_id` to `team_uuid` and `user_id` to `user_uuid` in the type spec
- Ensures type definitions match the actual database schema