### PR TITLE
Adds Mise Usage Instructions

### DIFF
--- a/.windsurf/rules/local-environment.md
+++ b/.windsurf/rules/local-environment.md
@@ -1,7 +1,5 @@
 ---
 trigger: always_on
-description: 
-globs: 
 ---
 
 # Local Environment
@@ -9,6 +7,9 @@ globs:
 ## Reference Commands
 
 ### Essential Commands
+
+This project uses [mise](https://mise.jdx.dev/) for managing Elixir and Erlang versions. To run Elixir or Erlang commands, prepend `mise exec --`, for example, `mise exec -- mix test` or `mise exec -- iex -S mix phx.server`.
+
 
 ```bash
 # Testing
@@ -29,7 +30,7 @@ mix phx.server                                # Start Phoenix server
 iex -S mix phx.server                         # Start with interactive shell
 ```
 
-# Database Management
+## Database Management
 
 - **Reset Development Databases**:
     - Use `mix reset.dev` to reset both EventStore and Ecto databases.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,8 @@ This is the backend API for the Reply Express application, built with Elixir and
 
 ## Essential Commands
 
+This project uses [mise](https://mise.jdx.dev/) for managing Elixir and Erlang versions. To run Elixir or Erlang commands, prepend `mise exec --`, for example, `mise exec -- mix test` or `mise exec -- iex -S mix phx.server`.
+
 ### Development Setup
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Essential Commands
 
+This project uses [mise](https://mise.jdx.dev/) for managing Elixir and Erlang versions. To run Elixir or Erlang commands, prepend `mise exec --`, for example, `mise exec -- mix test` or `mise exec -- iex -S mix phx.server`.
+
 ### Development Setup
 
 ```bash

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -36,6 +36,8 @@ database directly from a controller.
 
 ## 4. Development Workflow
 
+This project uses [mise](https://mise.jdx.dev/) for managing Elixir and Erlang versions. To run Elixir or Erlang commands, prepend `mise exec --`, for example, `mise exec -- mix test` or `mise exec -- iex -S mix phx.server`.
+
 ### Initial Setup
 
 1. Copy the example config: `cp config/dev.local.example.exs config/dev.local.exs` (and fill in values)


### PR DESCRIPTION
Adds instructions for using Mise to manage Elixir and Erlang versions to relevant documentation files.

This helps developers and AI agents set up the project environment correctly.

@coderabbitai ignore